### PR TITLE
Fix baseline pipeline bugs in OpenDPDv2.sh

### DIFF
--- a/bash_scripts/OpenDPDv2.sh
+++ b/bash_scripts/OpenDPDv2.sh
@@ -18,7 +18,13 @@ fi
 PYTHON_BIN=${PYTHON:-python}
 cd "${REPO_ROOT}"
 
-dataset_name=${DATASET_NAME:-APA_200MHz_backup}
+dataset_name=${DATASET_NAME:-APA_200MHz}
+if [[ ! -d "datasets/${dataset_name}" ]]; then
+  echo "[ERROR] Dataset directory 'datasets/${dataset_name}' not found. Set DATASET_NAME to one of:" >&2
+  ( cd datasets && ls -1d */ 2>/dev/null | sed 's#/$##' | grep -v -e '^__pycache__$' -e '^MATLAB$' || true ) >&2
+  exit 1
+fi
+
 accelerator=${ACCELERATOR:-cpu}
 devices=${DEVICES:-0}
 
@@ -48,10 +54,32 @@ quant_n_bits_w=${QUANT_BITS_W:-16}
 quant_n_bits_a=${QUANT_BITS_A:-16}
 quant_opts=(--quant --n_bits_w "${quant_n_bits_w}" --n_bits_a "${quant_n_bits_a}")
 
-printf '\033[32m==== Train PA model (dataset=%s) ====\033[0m\n' "${dataset_name}"
-"${PYTHON_BIN}" main.py --dataset_name "${dataset_name}" --step train_pa --accelerator "${accelerator}" --n_epochs "${n_epochs}"
-
 for i_seed in "${seed_values[@]}"; do
+  # Train the PA model per seed with the full architecture and training config;
+  # the DPD stage looks up the PA checkpoint by seed.
+  printf '\033[32m==== Train PA model (seed=%s, dataset=%s, backbone=%s) ====\033[0m\n' "${i_seed}" "${dataset_name}" "${PA_backbone}"
+  "${PYTHON_BIN}" main.py \
+    --dataset_name "${dataset_name}" \
+    --seed "${i_seed}" \
+    --step train_pa \
+    --accelerator "${accelerator}" \
+    --devices "${devices}" \
+    --PA_backbone "${PA_backbone}" \
+    --PA_hidden_size "${PA_hidden_size}" \
+    --PA_num_layers "${PA_num_layers}" \
+    --frame_length "${frame_length}" \
+    --frame_stride "${frame_stride}" \
+    --loss_type "${loss_type}" \
+    --opt_type "${opt_type}" \
+    --batch_size "${batch_size}" \
+    --batch_size_eval "${batch_size_eval}" \
+    --n_epochs "${n_epochs}" \
+    --lr_schedule "${lr_schedule}" \
+    --lr "${lr}" \
+    --lr_end "${lr_end}" \
+    --decay_factor "${decay_factor}" \
+    --patience "${patience}"
+
   for ((i=0; i<${#DPD_backbone[@]}; i++)); do
     printf '\033[32m==== Pre-training DPD (seed=%s, backbone=%s) ====\033[0m\n' "${i_seed}" "${DPD_backbone[$i]}"
     "${PYTHON_BIN}" main.py \
@@ -82,73 +110,79 @@ for i_seed in "${seed_values[@]}"; do
       --thh "${thh}"
 
     quant_dir_label="w${quant_n_bits_w}a${quant_n_bits_a}"
-    pretrained_pattern="./save/${dataset_name}/train_dpd/DPD_S_${i_seed}_M_${DPD_backbone[$i]^^}_H_${DPD_hidden_size[$i]}_F_${frame_length}"
-    pretrained_model=""
-    if pretrained_model=$(ls -1t ${pretrained_pattern}*.pt 2>/dev/null | head -n1 || true); then
-      printf '\033[32m==== Quantized aware training (label %s) ====\033[0m\n' "${quant_dir_label}"
-      "${PYTHON_BIN}" main.py \
-        --dataset_name "${dataset_name}" \
-        --seed "${i_seed}" \
-        --step train_dpd \
-        --accelerator "${accelerator}" \
-        --devices "${devices}" \
-        --PA_backbone "${PA_backbone}" \
-        --PA_hidden_size "${PA_hidden_size}" \
-        --PA_num_layers "${PA_num_layers}" \
-        --DPD_backbone "${DPD_backbone[$i]}" \
-        --DPD_hidden_size "${DPD_hidden_size[$i]}" \
-        --DPD_num_layers "${DPD_num_layers[$i]}" \
-        --frame_length "${frame_length}" \
-        --frame_stride "${frame_stride}" \
-        --loss_type "${loss_type}" \
-        --opt_type "${opt_type}" \
-        --batch_size "${batch_size}" \
-        --batch_size_eval "${batch_size_eval}" \
-        --n_epochs "${n_epochs}" \
-        --lr_schedule "${lr_schedule}" \
-        --lr "${lr}" \
-        --lr_end "${lr_end}" \
-        --decay_factor "${decay_factor}" \
-        --patience "${patience}" \
-        --quant_dir_label "${quant_dir_label}" \
-        --pretrained_model "${pretrained_model}" \
-        --thx "${thx}" \
-        --thh "${thh}" \
-        "${quant_opts[@]}"
 
-      printf '\033[32m==== Run DPD (label %s) ====\033[0m\n' "${quant_dir_label}"
-      "${PYTHON_BIN}" main.py \
-        --dataset_name "${dataset_name}" \
-        --seed "${i_seed}" \
-        --step run_dpd \
-        --accelerator "${accelerator}" \
-        --devices "${devices}" \
-        --PA_backbone "${PA_backbone}" \
-        --PA_hidden_size "${PA_hidden_size}" \
-        --PA_num_layers "${PA_num_layers}" \
-        --DPD_backbone "${DPD_backbone[$i]}" \
-        --DPD_hidden_size "${DPD_hidden_size[$i]}" \
-        --DPD_num_layers "${DPD_num_layers[$i]}" \
-        --frame_length "${frame_length}" \
-        --frame_stride "${frame_stride}" \
-        --loss_type "${loss_type}" \
-        --opt_type "${opt_type}" \
-        --batch_size "${batch_size}" \
-        --batch_size_eval "${batch_size_eval}" \
-        --n_epochs "${n_epochs}" \
-        --lr_schedule "${lr_schedule}" \
-        --lr "${lr}" \
-        --lr_end "${lr_end}" \
-        --decay_factor "${decay_factor}" \
-        --patience "${patience}" \
-        --quant_dir_label "${quant_dir_label}" \
-        --pretrained_model "${pretrained_model}" \
-        --thx "${thx}" \
-        --thh "${thh}" \
-        "${quant_opts[@]}"
-    else
-      printf '[WARN] Pretrained model not found for pattern %s*.pt. Skipping quantized training.\n' "${pretrained_pattern}" >&2
+    # The dense DPD checkpoint is saved under the PA-model subfolder. Resolve it
+    # and require it to exist so QAT fine-tunes it instead of training anew.
+    pa_subdir="PA_S_${i_seed}_M_${PA_backbone^^}_H_${PA_hidden_size}_F_${frame_length}"
+    pretrained_pattern="./save/${dataset_name}/train_dpd/${pa_subdir}/DPD_S_${i_seed}_M_${DPD_backbone[$i]^^}_H_${DPD_hidden_size[$i]}_F_${frame_length}"
+    pretrained_model=$(ls -1t ${pretrained_pattern}*.pt 2>/dev/null | head -n1 || true)
+    if [[ -z "${pretrained_model}" || ! -f "${pretrained_model}" ]]; then
+      echo "[ERROR] Pretrained dense DPD model not found for pattern ${pretrained_pattern}*.pt" >&2
+      exit 1
     fi
+    printf '[INFO] QAT will fine-tune from: %s\n' "${pretrained_model}"
+
+    printf '\033[32m==== Quantized aware training (label %s) ====\033[0m\n' "${quant_dir_label}"
+    "${PYTHON_BIN}" main.py \
+      --dataset_name "${dataset_name}" \
+      --seed "${i_seed}" \
+      --step train_dpd \
+      --accelerator "${accelerator}" \
+      --devices "${devices}" \
+      --PA_backbone "${PA_backbone}" \
+      --PA_hidden_size "${PA_hidden_size}" \
+      --PA_num_layers "${PA_num_layers}" \
+      --DPD_backbone "${DPD_backbone[$i]}" \
+      --DPD_hidden_size "${DPD_hidden_size[$i]}" \
+      --DPD_num_layers "${DPD_num_layers[$i]}" \
+      --frame_length "${frame_length}" \
+      --frame_stride "${frame_stride}" \
+      --loss_type "${loss_type}" \
+      --opt_type "${opt_type}" \
+      --batch_size "${batch_size}" \
+      --batch_size_eval "${batch_size_eval}" \
+      --n_epochs "${n_epochs}" \
+      --lr_schedule "${lr_schedule}" \
+      --lr "${lr}" \
+      --lr_end "${lr_end}" \
+      --decay_factor "${decay_factor}" \
+      --patience "${patience}" \
+      --quant_dir_label "${quant_dir_label}" \
+      --pretrained_model "${pretrained_model}" \
+      --thx "${thx}" \
+      --thh "${thh}" \
+      "${quant_opts[@]}"
+
+    printf '\033[32m==== Run DPD (label %s) ====\033[0m\n' "${quant_dir_label}"
+    "${PYTHON_BIN}" main.py \
+      --dataset_name "${dataset_name}" \
+      --seed "${i_seed}" \
+      --step run_dpd \
+      --accelerator "${accelerator}" \
+      --devices "${devices}" \
+      --PA_backbone "${PA_backbone}" \
+      --PA_hidden_size "${PA_hidden_size}" \
+      --PA_num_layers "${PA_num_layers}" \
+      --DPD_backbone "${DPD_backbone[$i]}" \
+      --DPD_hidden_size "${DPD_hidden_size[$i]}" \
+      --DPD_num_layers "${DPD_num_layers[$i]}" \
+      --frame_length "${frame_length}" \
+      --frame_stride "${frame_stride}" \
+      --loss_type "${loss_type}" \
+      --opt_type "${opt_type}" \
+      --batch_size "${batch_size}" \
+      --batch_size_eval "${batch_size_eval}" \
+      --n_epochs "${n_epochs}" \
+      --lr_schedule "${lr_schedule}" \
+      --lr "${lr}" \
+      --lr_end "${lr_end}" \
+      --decay_factor "${decay_factor}" \
+      --patience "${patience}" \
+      --quant_dir_label "${quant_dir_label}" \
+      --pretrained_model "${pretrained_model}" \
+      --thx "${thx}" \
+      --thh "${thh}" \
+      "${quant_opts[@]}"
   done
 
 done

--- a/steps/run_dpd.py
+++ b/steps/run_dpd.py
@@ -44,7 +44,11 @@ def main(proj: Project):
     net_dpd = model.CoreModel(input_size=2,  # I and Q
                               hidden_size=proj.DPD_hidden_size,
                               num_layers=proj.DPD_num_layers,
-                              backbone_type=proj.DPD_backbone)
+                              backbone_type=proj.DPD_backbone,
+                              window_size=proj.window_size,
+                              num_dvr_units=proj.num_dvr_units,
+                              thx=proj.thx,
+                              thh=proj.thh)
 
     net_dpd = get_quant_model(proj, net_dpd)
     


### PR DESCRIPTION
A few issues in the `OpenDPDv2.sh` have been found, fixed and ready for review:

- train_pa: forward the PA backbone/architecture args and the shared training hyperparameters, and run per seed inside the loop. Previously train_pa received only dataset/accelerator/n_epochs, so it trained a GRU PA (argparse default) with default hyperparameters (lr 5e-4, no LR schedule, batch 256) and the DPD stage then failed to load the expected DGRU PA checkpoint.

- QAT: resolve the pretrained dense DPD checkpoint under the PA-model subfolder and require the file to exist, aborting otherwise. The old glob missed the PA subfolder and the guard was always true, so QAT ran with --pretrained_model "" and silently trained from scratch.

- Default DATASET_NAME to APA_200MHz (was the non-existent APA_200MHz_backup) and fail fast with a clear message when the dataset directory is missing.

- run_dpd.py: forward thx/thh/window_size/num_dvr_units when building the DPD model, matching train_dpd.py. Without them the exported waveform was computed dense (zero delta thresholds) regardless of the configured sparsity.