### PR TITLE
docs: use current Studio and EMI logos in README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,13 @@
 
 <!-- --8<-- [start:brand] -->
 <p>
-  <a href="https://github.com/lab-emi/OpenDPD">
-    <picture class="brand-logo">
-      <source media="(prefers-color-scheme: dark)" srcset="frontend/src/assets/opendpd-studio-logo-inverse.svg" />
-      <img src="frontend/src/assets/opendpd-studio-logo.svg" alt="OpenDPD Studio" width="300" />
-    </picture>
-  </a>
+  <a href="https://github.com/lab-emi/OpenDPD"><picture class="brand-logo"><source
+    media="(prefers-color-scheme: dark)" srcset="frontend/src/assets/opendpd-studio-logo-inverse.svg" /><img
+    src="frontend/src/assets/opendpd-studio-logo.svg" alt="OpenDPD Studio" width="300" align="middle" /></picture></a>
   &nbsp;
-  <a href="https://www.tudemi.com/">
-    <picture class="brand-logo">
-      <source media="(prefers-color-scheme: dark)" srcset="frontend/src/assets/emi-logo-inverse.svg" />
-      <img src="frontend/src/assets/emi-logo.svg" alt="EMI Lab — Efficient Machine Intelligence, TU Delft" width="150" />
-    </picture>
-  </a>
+  <a href="https://www.tudemi.com/"><picture class="brand-logo"><source
+    media="(prefers-color-scheme: dark)" srcset="frontend/src/assets/emi-logo-inverse.svg" /><img
+    src="frontend/src/assets/emi-logo.svg" alt="EMI Lab — Efficient Machine Intelligence, TU Delft" width="150" align="middle" /></picture></a>
 </p>
 <!-- --8<-- [end:brand] -->
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 
 # OpenDPD
 
+<!-- --8<-- [start:brand] -->
+<p>
+  <a href="https://github.com/lab-emi/OpenDPD">
+    <picture class="brand-logo">
+      <source media="(prefers-color-scheme: dark)" srcset="frontend/src/assets/opendpd-studio-logo-inverse.svg" />
+      <img src="frontend/src/assets/opendpd-studio-logo.svg" alt="OpenDPD Studio" width="300" />
+    </picture>
+  </a>
+  &nbsp;
+  <a href="https://www.tudemi.com/">
+    <picture class="brand-logo">
+      <source media="(prefers-color-scheme: dark)" srcset="frontend/src/assets/emi-logo-inverse.svg" />
+      <img src="frontend/src/assets/emi-logo.svg" alt="EMI Lab — Efficient Machine Intelligence, TU Delft" width="150" />
+    </picture>
+  </a>
+</p>
+<!-- --8<-- [end:brand] -->
+
 <!-- --8<-- [start:intro] -->
 **Model a power amplifier. Train a digital predistorter. Understand the result.**
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -17,6 +17,7 @@ The GitHub README is the short entry point; the documentation site is the place 
 | Scientific definitions and acceptance evidence | `docs/protocols/`, `docs/releases/` | Link from guides; do not restate thresholds in the README. |
 | Site navigation | `mkdocs.yml` | Organize by user task without moving existing page URLs. |
 | Shared images | `pics/` | Published by `docs/hooks/assets.py`; keep one copy. |
+| Studio and EMI logos | `frontend/src/assets/`; root `README.md`, `brand` section | The site includes the same brand section and publishes the original SVGs through the asset hook. |
 
 `docs/index.md`, `docs/datasets.md`, `docs/examples.md` and `docs/benchmark/index.md` are site entry pages. They compose canonical content with `pymdownx.snippets`; they are not a second place to edit that content. The installation page reuses only the short command block. When reading its Markdown on GitHub, that block is available in the root README.
 
@@ -24,7 +25,7 @@ The GitHub README is the short entry point; the documentation site is the place 
 
 - Keep README focused on the screenshot, current capability, first run, workflow and next steps. Move long option lists, experiment settings and paper tables to a guide.
 - Use normal relative Markdown links in guides. Link to the canonical source, not to a site wrapper when writing a GitHub entry point.
-- Site-only links belong in `docs/index.md` or `mkdocs.yml`. Shared README snippets contain context-neutral text, external links, or root `pics/` images so they work when included on the site home page.
+- Site-only links belong in `docs/index.md` or `mkdocs.yml`. Shared README snippets contain context-neutral text, external links, or repository-root image paths published by the asset hook so they work when included on the site home page.
 - For images in a standalone guide, use the repository-relative path, such as `../pics/platform.png` from `docs/about.md`. The asset hook adjusts that path for the site build.
 - Keep existing page filenames when reorganizing navigation. Update links and anchors if a heading changes.
 - Mark development previews separately from released packages. Check the actual package extras, CLI flags and UI before documenting an installation or feature.
@@ -52,3 +53,9 @@ The existing **Docs** workflow builds PRs and publishes the site from `main`. No
 ## Refresh the Studio screenshot
 
 Use the current app with a separate clean workspace, English selected, the light theme active and no private paths, captures or user run names visible. Capture the real Home page after it has loaded, with **Get Started** visible, and replace `pics/studio-home.png`. Keep browser diagnostics and session files out of Git. The README and site will both pick up the same image.
+
+## Update the brand logos
+
+Reuse the transparent SVGs from `frontend/src/assets/`, including their light and dark variants. Keep the EMI inverse variant's geometry identical to `emi-logo.svg`; only the ink colors differ. The site header uses the Studio emblem; its favicon reuses `frontend/public/favicon.svg`. Do not rasterize the logos or copy them into `pics/`.
+
+The README's `brand` snippet uses GitHub-compatible `<picture class="brand-logo">` elements, each with a dark `source` and a light fallback `img`. Keep these child tags self-closing. During the site build, `docs/hooks/assets.py` converts them to Material's `#only-light` / `#only-dark` images, so the site's own theme toggle works independently of the system theme. Check both themes and a narrow viewport when changing this section.

--- a/docs/hooks/assets.py
+++ b/docs/hooks/assets.py
@@ -7,18 +7,37 @@ repository-relative paths so their Markdown also works directly on GitHub.
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 from pathlib import Path
+from xml.etree import ElementTree
 
 from mkdocs.structure.files import File, Files
 
 ROOT = Path(__file__).resolve().parents[2]
 ASSET_DIRS = ["pics"]
 ASSET_FILES = [
+    "frontend/src/assets/opendpd-studio-logo.svg",
+    "frontend/src/assets/opendpd-studio-logo-inverse.svg",
+    "frontend/src/assets/opendpd-studio-mark.svg",
+    "frontend/public/favicon.svg",
+    "frontend/src/assets/emi-logo.svg",
+    "frontend/src/assets/emi-logo-inverse.svg",
     "benchmark/benchmark_results.png",
     "benchmark/benchmark_delta_dpd_results.png",
     "benchmark/reproduce_benchmark_report.sh",
     "benchmark/results/benchmark_report_results.json",
 ]
+
+
+def _theme_logo(match):
+    """Map the shared GitHub picture markup to Material's palette-aware images."""
+    picture = ElementTree.fromstring(match.group(0))
+    light = picture.find("img")
+    source = picture.find("source")
+    dark = deepcopy(light)
+    dark.set("src", source.attrib["srcset"] + "#only-dark")
+    light.set("src", light.attrib["src"] + "#only-light")
+    return ElementTree.tostring(light, encoding="unicode") + ElementTree.tostring(dark, encoding="unicode")
 
 
 def on_page_markdown(markdown, page, **kwargs):
@@ -27,6 +46,11 @@ def on_page_markdown(markdown, page, **kwargs):
     repo_prefix = "../" * (depth + 1) + "pics/"
     site_prefix = "../" * depth + "pics/"
     return re.sub(r"(?<=\]\()" + re.escape(repo_prefix), site_prefix, markdown)
+
+
+def on_page_content(html, **kwargs):
+    """Apply site-specific theming after README snippets have been expanded."""
+    return re.sub(r'<picture class="brand-logo">.*?</picture>', _theme_logo, html, flags=re.DOTALL)
 
 
 def on_files(files: Files, config) -> Files:

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ title: Home
 
 # OpenDPD
 
+--8<-- "README.md:brand"
+
 --8<-- "README.md:intro"
 
 [Get started with Studio](install.md){ .md-button .md-button--primary }

--- a/frontend/src/assets/emi-logo-inverse.svg
+++ b/frontend/src/assets/emi-logo-inverse.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 254.6 84" width="254.6" height="84" role="img" aria-labelledby="t d">
+<title id="t">EMI</title><desc id="d">EMI Lab, Efficient Machine Intelligence at TU Delft. A brain wired with circuit traces beside the letters EMI.</desc>
+<g fill="none" stroke="#f4f9fc" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M18.5 4.5L18.5 14.5L25.5 21.5L35.34 21.5M4.5 20L14 20L23 29L32.38 29M11 29L20 38L31.03 38M11 55L20 46L31.03 46M4.5 64L14 64L23 55L32.38 55M18.5 79.5L18.5 69.5L25.5 62.5L35.34 62.5M81.5 4.5L81.5 14.5L74.5 21.5L64.66 21.5M95.5 20L86 20L77 29L67.62 29M89 29L80 38L68.97 38M89 55L80 46L68.97 46M95.5 64L86 64L77 55L67.62 55M81.5 79.5L81.5 69.5L74.5 62.5L64.66 62.5M33.5 4.5L39.5 10.5L60.5 10.5L66.5 4.5M33.5 79.5L39.5 73.5L60.5 73.5L66.5 79.5"/>
+<path d="M50 20.5C48.6 17.6 44.6 16.2 40.5 17C34.4 18.2 30.5 29 30.5 42C30.5 55 34.4 65.8 40.5 67C44.6 67.8 48.6 66.4 50 63.5M50 20.5C51.4 17.6 55.4 16.2 59.5 17C65.6 18.2 69.5 29 69.5 42C69.5 55 65.6 65.8 59.5 67C55.4 67.8 51.4 66.4 50 63.5M50 19.6V64.4"/>
+<path stroke-width="2.8" d="M36 25.5C39.5 25 40.5 30 44.5 31M32.4 43C35.5 39 40.5 44.5 45.5 40.5M36 58.5C39.5 59 40.5 54 44.5 53M64 25.5C60.5 25 59.5 30 55.5 31M67.6 43C64.5 39 59.5 44.5 54.5 40.5M64 58.5C60.5 59 59.5 54 55.5 53"/>
+<g fill="#101f31" stroke="#f4f9fc">
+<circle cx="18.5" cy="4.5" r="2.9"/><circle cx="4.5" cy="20" r="2.9"/><circle cx="11" cy="29" r="2.9"/><circle cx="11" cy="55" r="2.9"/><circle cx="4.5" cy="64" r="2.9"/><circle cx="18.5" cy="79.5" r="2.9"/><circle cx="81.5" cy="4.5" r="2.9"/><circle cx="95.5" cy="20" r="2.9"/><circle cx="89" cy="29" r="2.9"/><circle cx="89" cy="55" r="2.9"/><circle cx="95.5" cy="64" r="2.9"/><circle cx="81.5" cy="79.5" r="2.9"/><circle cx="33.5" cy="4.5" r="2.9"/><circle cx="66.5" cy="4.5" r="2.9"/><circle cx="33.5" cy="79.5" r="2.9"/><circle cx="66.5" cy="79.5" r="2.9"/>
+</g></g>
+<g fill="#37b9e8">
+<path transform="translate(103 78) scale(0.05 -0.05)" d="M140 0V1440H1080V1186H412V878H960V624H412V254H1080V0Z"/>
+<path transform="translate(154.5 78) scale(0.05 -0.05)" d="M140 0V1440H384L860 484L1336 1440H1580V0H1326V860L908 0H812L394 860V0Z"/>
+<path transform="translate(233 78) scale(0.05 -0.05)" d="M160 0V1440H432V0Z"/>
+</g></svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,8 +18,8 @@ copyright: Copyright &copy; Lab of Efficient Machine Intelligence, Delft Univers
 
 theme:
   name: material
-  logo: pics/OpenDPDlogo.svg
-  favicon: pics/OpenDPDlogo.svg
+  logo: frontend/src/assets/opendpd-studio-mark.svg
+  favicon: frontend/public/favicon.svg
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
Add the current transparent OpenDPD Studio and EMI Lab wordmarks below the README's light-theme Home screenshot, with links to the repository and lab. GitHub selects the appropriate SVG for each theme. The documentation homepage includes the same README snippet and publishes the canonical frontend assets; its own palette toggle selects matching artwork. The site header and favicon also use the Studio emblem.

The EMI dark variant preserves the existing geometry and changes only ink colors. No application behavior, training code or scientific semantics change.

Validation:
- `python -m mkdocs build --strict` passed (macOS, Python 3.13).
- Real browser review at 1440 × 1000 and 390 × 844, both palettes: all logos loaded, exactly one variant per brand visible, correct links, no horizontal overflow. Site palette switching was checked independently of the system theme.
- Verified published SVGs match the original assets byte-for-byte, EMI variants have identical geometry, and the existing light-theme screenshot is unchanged.
- `git diff --check` passed.
