### PR TITLE
Preserve final batch progress after experiment replay

### DIFF
--- a/frontend/src/components/LiveRunDashboard.test.tsx
+++ b/frontend/src/components/LiveRunDashboard.test.tsx
@@ -35,6 +35,16 @@ test('epoch completion stays stable when validation starts a new batch counter',
   expect(screen.getByRole('progressbar', { name: 'Batch progress' })).toHaveAttribute('aria-valuenow', '10')
 })
 
+test('completion events do not replace the last saved batch with an empty counter', async () => {
+  mockApi({ [`GET /api/v1/runs/${run.run_id}/live`]: () => ({
+    geometry: null, preview: null, last_batch: { phase: 'evaluate', batch: 6, total_batches: 6, sequences: 6, sequence_samples: 2560 },
+  }) })
+  renderWithProviders(<LiveRunDashboard run={{ ...run, status: 'succeeded' }} stream={{ ...stream, batchProgress: { phase: 'completed' } }} metrics={[]} />)
+  expect(await screen.findByText(/Batch 6 \/ 6/)).toBeInTheDocument()
+  expect(screen.queryByText(/Batch 0 \/ —/)).not.toBeInTheDocument()
+  expect(screen.getByRole('progressbar', { name: 'Batch progress' })).toHaveAttribute('aria-valuenow', '100')
+})
+
 test('a spectral-profile DPD test shows its own metrics without an epoch curve', async () => {
   mockApi({ [`GET /api/v1/runs/${run.run_id}/live`]: () => ({
     policy: { min_batches: 25, min_seconds: 2, overhead_target: .05 }, geometry: null,

--- a/frontend/src/components/LiveRunDashboard.tsx
+++ b/frontend/src/components/LiveRunDashboard.tsx
@@ -40,7 +40,9 @@ export function LiveRunDashboard({ run, stream, metrics }: { run: RunView; strea
   const active = !isTerminal(run.status)
   const query = useQuery({ queryKey: liveKey(run.run_id), queryFn: ({ signal }) => api.get<LiveSnapshot>(`/runs/${encodeURIComponent(run.run_id)}/live`, signal), refetchInterval: active ? (WEB_MODE ? 5000 : 2000) : false, retry: false })
   const snapshot = query.data, preview = snapshot?.preview, geometry = snapshot?.training_geometry ?? snapshot?.geometry
-  const progress = stream.batchProgress ?? snapshot?.last_batch
+  // Stage transitions have no batch counters. Keep the last real batch from
+  // the persisted snapshot when replay ends with a completed-stage event.
+  const progress = stream.batchProgress?.total_batches ? stream.batchProgress : snapshot?.last_batch ?? stream.batchProgress
   const spec = preview?.plots.spectrum, time = preview?.plots.time
   const spectra = useMemo(() => (spec?.traces ?? []).map((trace) => ({ name: trace.name, psdDb: trace.psd_db })), [spec])
   const series = useMemo(() => time?.traces ?? [], [time])
@@ -76,7 +78,7 @@ export function LiveRunDashboard({ run, stream, metrics }: { run: RunView; strea
         <LinearProgress variant="determinate" value={epochPercent} aria-label={t('live.epochProgress')} />
       </Box>}
       {(active || training) && <Box sx={{ mt: 2 }} data-testid="batch-progress">
-        <Stack direction="row" sx={{ justifyContent: 'space-between', mb: .75 }}><Typography variant="body2">{progress?.epoch !== undefined && active ? `${t('live.currentEpoch', { epoch: progress.epoch + 1 })} · ` : ''}{progress?.phase ? phaseLabel(progress.phase) : message(run.status)} · {t('live.batch', { batch: progress?.batch ?? 0, total: progress?.total_batches ?? '—' })}</Typography><Typography variant="body2">{Math.round(run.status === 'succeeded' ? 100 : batchPercent)}%</Typography></Stack>
+        <Stack direction="row" sx={{ justifyContent: 'space-between', mb: .75 }}><Typography variant="body2">{progress?.epoch !== undefined && active ? `${t('live.currentEpoch', { epoch: progress.epoch + 1 })} · ` : ''}{progress?.phase ? phaseLabel(progress.phase) : message(run.status)} · {progress?.total_batches ? t('live.batch', { batch: progress.batch ?? 0, total: progress.total_batches }) : t(active ? 'live.preparing' : 'live.batchProgress')}</Typography><Typography variant="body2">{Math.round(run.status === 'succeeded' ? 100 : batchPercent)}%</Typography></Stack>
         <LinearProgress variant={active && !progress?.total_batches ? 'indeterminate' : 'determinate'} value={run.status === 'succeeded' ? 100 : batchPercent} aria-label={t('live.batchProgress')} />
       </Box>}
       {training && <ModelDownloadButton run={run} />}


### PR DESCRIPTION
After a successful remote Mac mini CSV/CUDA training run, replay could end on a `completed` stage event without batch counters and display “Batch 0 / —” beside a full bar. Studio now uses the persisted last batch when a stage event has no counters, and avoids displaying invented zero counts if no saved batch exists.

Validated with the targeted dashboard interaction tests, strict TypeScript, production build and lint. The new regression test replays a completion event over a persisted 6/6 batch. This completes the 2.2.0 visual acceptance finding; the prior 100-epoch CUDA run, live/final checkpoint downloads, weight-only loading and final SHA-256 verification all passed on the remote Mac mini.
