### PR TITLE
Add Report bugs to Studio and release 2.2.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use OpenDPD, its Studio or its benchmark, please cite the software and the paper below (docs/community/citation.md)."
 title: "OpenDPD"
 type: software
-version: 2.2.1
+version: 2.2.2
 license: Apache-2.0
 repository-code: "https://github.com/lab-emi/OpenDPD"
 authors:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ OpenDPD is a PyTorch framework for power amplifier (PA) modeling and digital pre
 ## What's new
 
 <!-- --8<-- [start:studio-features] -->
-**OpenDPD 2.2.1** accelerates CUDA training in OpenDPD Studio:
+**OpenDPD 2.2.2** adds **Report bugs** to the top of Studio. The description box opens with the cursor ready; continue directly to a prefilled GitHub issue to review and submit your report. The same control is available when the compute server cannot be reached.
+
+See the [2.2.2 release notes](https://github.com/lab-emi/OpenDPD/blob/main/docs/releases/release-notes-2.2.2.md). CUDA training improvements from 2.2.1 remain available:
 
 - CUDA replay for supported native models reduces dispatch overhead while retaining the existing optimizer, precision, batches and scheduler.
 - Quick/full training defaults are 10/150 epochs; plots reuse validation predictions once per epoch.
@@ -59,7 +61,7 @@ For a hosted installation, the [public Studio deployment guide](https://lab-emi.
 **[Open the hosted Studio now](https://opendpd.com/studio/)**, or install the packaged local app with **Python 3.10–3.13**:
 
 ```bash
-python -m pip install "opendpd[gui]==2.2.1"
+python -m pip install "opendpd[gui]==2.2.2"
 opendpd gui
 ```
 

--- a/docs/contracts/openapi.json
+++ b/docs/contracts/openapi.json
@@ -6414,7 +6414,7 @@
             "title": "Csrf Token"
           },
           "version": {
-            "default": "2.2.1",
+            "default": "2.2.2",
             "title": "Version",
             "type": "string"
           }
@@ -7737,7 +7737,7 @@
   },
   "info": {
     "title": "OpenDPD Studio API",
-    "version": "2.2.1"
+    "version": "2.2.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/releases/release-notes-2.2.2.md
+++ b/docs/releases/release-notes-2.2.2.md
@@ -1,0 +1,12 @@
+# OpenDPD 2.2.2 — Report bugs from Studio
+
+Try [OpenDPD Studio](https://opendpd.com/studio/) or install `pip install -U "opendpd[gui]==2.2.2"`.
+
+- Add **Report bugs** to the GUI toolbar, including a compact mobile control. It is also available before a session starts and when the compute server cannot be reached.
+- Open a description box with keyboard focus ready for typing. **Continue on GitHub** opens the OpenDPD repository's new-issue form in a separate tab, with the description and public Studio version filled in. The user reviews and submits the issue on GitHub; the running experiment stays open.
+- Keep the draft when the dialog is dismissed, restore keyboard focus to the toolbar, and handle descriptions that are too long to pass through GitHub's URL form.
+- Translate the reporting flow into all nine interface languages. Workspace paths, tokens, datasets, logs and experiment details are not automatically attached.
+
+GitHub's own form controls its initial keyboard focus and currently focuses the title. Studio's small description dialog provides reliable focus without depending on GitHub's generated element IDs or cross-origin scripting. GitHub sign-in may be required to submit an issue.
+
+CUDA training, 10/150-epoch defaults, preview cadence, upload validation, isolation and 24-hour cleanup are unchanged from 2.2.1.

--- a/docs/tutorials/gui-quickstart.md
+++ b/docs/tutorials/gui-quickstart.md
@@ -1,6 +1,6 @@
 # Your first experiment in Studio
 
-Open [Studio on the web](https://opendpd.com/studio/), or install the packaged local app with `pip install "opendpd[gui]==2.2.1"`.
+Open [Studio on the web](https://opendpd.com/studio/), or install the packaged local app with `pip install "opendpd[gui]==2.2.2"`.
 
 ```bash
 opendpd gui

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opendpd-studio",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opendpd-studio",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendpd-studio",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/schema.ts
+++ b/frontend/src/api/schema.ts
@@ -3282,7 +3282,7 @@ export interface components {
             csrf_token?: string | null;
             /**
              * Version
-             * @default 2.2.1
+             * @default 2.2.2
              */
             version: string;
         };

--- a/frontend/src/components/ReportBugsButton.tsx
+++ b/frontend/src/components/ReportBugsButton.tsx
@@ -1,0 +1,52 @@
+import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+import IconButton from '@mui/material/IconButton'
+import TextField from '@mui/material/TextField'
+import Tooltip from '@mui/material/Tooltip'
+import { useId, useRef, useState } from 'react'
+import { version } from '../../package.json'
+import { t } from '@/i18n'
+
+const NEW_ISSUE = 'https://github.com/lab-emi/OpenDPD/issues/new'
+
+/** Only the user's description and the public app version leave Studio. */
+function issueUrl(description: string): string {
+  const url = new URL(NEW_ISSUE)
+  url.searchParams.set('title', '[Bug] OpenDPD Studio')
+  url.searchParams.set('body', `${description.trim()}\n\n---\nOpenDPD Studio ${version}`)
+  return url.href
+}
+
+export function ReportBugsButton({ compact = false }: { compact?: boolean }) {
+  const [open, setOpen] = useState(false)
+  const [description, setDescription] = useState('')
+  const trigger = useRef<HTMLButtonElement>(null)
+  const id = useId()
+  const href = issueUrl(description)
+  // Account for encoded Unicode, not just the textarea's character count.
+  const tooLong = href.length > 7500
+  const ready = description.trim().length > 0 && !tooLong
+  const show = (event: React.MouseEvent<HTMLButtonElement>) => { event.currentTarget.blur(); setOpen(true) }
+  const label = t('bugs.report')
+  return <>
+    {compact ? <Tooltip title={label}><IconButton ref={trigger} aria-label={label} onClick={show} color="primary" sx={{ width: 40, height: 40, flexShrink: 0 }}><BugReportOutlinedIcon fontSize="small" /></IconButton></Tooltip>
+      : <Button ref={trigger} size="small" variant="outlined" startIcon={<BugReportOutlinedIcon />} onClick={show} sx={{ whiteSpace: 'nowrap', flexShrink: 0 }}>{label}</Button>}
+    <Dialog open={open} onClose={() => setOpen(false)} maxWidth="sm" fullWidth disableRestoreFocus aria-labelledby={`${id}-title`} aria-describedby={`${id}-help`} slotProps={{ transition: { onExited: () => trigger.current?.focus() } }}>
+      <DialogTitle id={`${id}-title`}>{label}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id={`${id}-help`} sx={{ mb: 2 }}>{t('bugs.help')}</DialogContentText>
+        <TextField autoFocus fullWidth multiline minRows={6} maxRows={12} label={t('bugs.description')} placeholder={t('bugs.placeholder')} value={description} onChange={(event) => setDescription(event.target.value)} error={tooLong} helperText={tooLong ? t('bugs.tooLong') : undefined} />
+      </DialogContent>
+      <DialogActions sx={{ flexWrap: 'wrap', gap: 1, px: 3, pb: 2 }}>
+        <Button onClick={() => setOpen(false)}>{t('form.cancel')}</Button>
+        <Button component="a" href={ready ? href : undefined} target="_blank" rel="noopener noreferrer" variant="contained" disabled={!ready} endIcon={<OpenInNewIcon />} onClick={() => setOpen(false)}>{t('bugs.continue')}</Button>
+      </DialogActions>
+    </Dialog>
+  </>
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "Batches zwischen Vorschauen",
   "form.preview.warning": "Häufige Batch-Vorschauen können das Training stark verlangsamen. Jede Vorschau benötigt zusätzliche Inferenz und Diagrammberechnungen.",
   "live.cadence.epoch": "Diagramme werden einmal pro Epoche aktualisiert.",
-  "live.cadence.batch": "Diagramme werden alle {batches} Batches und am Epochenende aktualisiert."
+  "live.cadence.batch": "Diagramme werden alle {batches} Batches und am Epochenende aktualisiert.",
+  "bugs.report": "Fehler melden",
+  "bugs.help": "Beschreibe hier das Problem und prüfe und veröffentliche anschließend das neue Issue auf GitHub. Dort kannst du Screenshots hinzufügen.",
+  "bugs.description": "Fehlerbeschreibung",
+  "bugs.placeholder": "Was ist passiert? Was hast du erwartet? Wie lässt sich das Problem reproduzieren?",
+  "bugs.tooLong": "Diese Beschreibung ist zu lang zum Übertragen. Kürze sie und ergänze die übrigen Details auf GitHub.",
+  "bugs.continue": "Weiter auf GitHub"
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "Batches between previews",
   "form.preview.warning": "Frequent batch previews may severely slow down training. Each preview performs extra inference and plot calculations.",
   "live.cadence.epoch": "Plots update once per epoch.",
-  "live.cadence.batch": "Plots update every {batches} batches and at epoch end."
+  "live.cadence.batch": "Plots update every {batches} batches and at epoch end.",
+  "bugs.report": "Report bugs",
+  "bugs.help": "Describe the problem here, then continue on GitHub to review and submit your new issue. You can add screenshots there.",
+  "bugs.description": "Bug description",
+  "bugs.placeholder": "What happened? What did you expect? How can we reproduce it?",
+  "bugs.tooLong": "This description is too long to transfer. Shorten it, then add the remaining details on GitHub.",
+  "bugs.continue": "Continue on GitHub"
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "Lotes entre vistas previas",
   "form.preview.warning": "Las vistas previas frecuentes pueden ralentizar mucho el entrenamiento. Cada una requiere inferencia y cálculos gráficos adicionales.",
   "live.cadence.epoch": "Los gráficos se actualizan una vez por época.",
-  "live.cadence.batch": "Los gráficos se actualizan cada {batches} lotes y al final de la época."
+  "live.cadence.batch": "Los gráficos se actualizan cada {batches} lotes y al final de la época.",
+  "bugs.report": "Informar de errores",
+  "bugs.help": "Describe el problema aquí y continúa en GitHub para revisar y enviar tu nueva incidencia. Allí puedes añadir capturas de pantalla.",
+  "bugs.description": "Descripción del error",
+  "bugs.placeholder": "¿Qué ocurrió? ¿Qué esperabas? ¿Cómo podemos reproducirlo?",
+  "bugs.tooLong": "La descripción es demasiado larga para transferirla. Acórtala y añade los demás detalles en GitHub.",
+  "bugs.continue": "Continuar en GitHub"
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "Lots entre les aperçus",
   "form.preview.warning": "Des aperçus fréquents peuvent fortement ralentir l’entraînement. Chaque aperçu nécessite une inférence et des calculs graphiques supplémentaires.",
   "live.cadence.epoch": "Les graphiques sont actualisés une fois par époque.",
-  "live.cadence.batch": "Actualisation tous les {batches} lots et en fin d’époque."
+  "live.cadence.batch": "Actualisation tous les {batches} lots et en fin d’époque.",
+  "bugs.report": "Signaler un bug",
+  "bugs.help": "Décrivez le problème ici, puis continuez sur GitHub pour vérifier et envoyer votre nouvelle issue. Vous pourrez y ajouter des captures d’écran.",
+  "bugs.description": "Description du bug",
+  "bugs.placeholder": "Que s’est-il passé ? Quel résultat attendiez-vous ? Comment reproduire le problème ?",
+  "bugs.tooLong": "Cette description est trop longue à transférer. Raccourcissez-la, puis ajoutez les autres détails sur GitHub.",
+  "bugs.continue": "Continuer sur GitHub"
 }

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "Batch tra le anteprime",
   "form.preview.warning": "Anteprime frequenti possono rallentare molto l’addestramento. Ogni anteprima richiede inferenza e calcoli grafici aggiuntivi.",
   "live.cadence.epoch": "I grafici si aggiornano una volta per epoca.",
-  "live.cadence.batch": "I grafici si aggiornano ogni {batches} batch e alla fine dell’epoca."
+  "live.cadence.batch": "I grafici si aggiornano ogni {batches} batch e alla fine dell’epoca.",
+  "bugs.report": "Segnala bug",
+  "bugs.help": "Descrivi qui il problema, poi continua su GitHub per controllare e inviare la nuova issue. Potrai aggiungere screenshot lì.",
+  "bugs.description": "Descrizione del bug",
+  "bugs.placeholder": "Che cosa è successo? Che cosa ti aspettavi? Come possiamo riprodurre il problema?",
+  "bugs.tooLong": "La descrizione è troppo lunga da trasferire. Accorciala, poi aggiungi gli altri dettagli su GitHub.",
+  "bugs.continue": "Continua su GitHub"
 }

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "プレビュー間のバッチ数",
   "form.preview.warning": "バッチごとの頻繁なプレビューは学習を大幅に遅くする可能性があります。毎回、追加の推論とプロット計算を行います。",
   "live.cadence.epoch": "プロットはエポックごとに更新されます。",
-  "live.cadence.batch": "{batches} バッチごととエポック終了時に更新されます。"
+  "live.cadence.batch": "{batches} バッチごととエポック終了時に更新されます。",
+  "bugs.report": "バグを報告",
+  "bugs.help": "ここで問題を説明し、GitHub で新しい Issue を確認して送信してください。スクリーンショットもそこで追加できます。",
+  "bugs.description": "バグの説明",
+  "bugs.placeholder": "何が起きましたか？期待した結果は何ですか？再現手順を教えてください。",
+  "bugs.tooLong": "説明が長すぎて転送できません。短くしてから、残りの詳細を GitHub で追加してください。",
+  "bugs.continue": "GitHub に進む"
 }

--- a/frontend/src/i18n/ko.json
+++ b/frontend/src/i18n/ko.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "미리보기 간 배치 수",
   "form.preview.warning": "빈번한 배치 미리보기는 학습 속도를 크게 떨어뜨릴 수 있습니다. 매번 추가 추론과 플롯 계산이 수행됩니다.",
   "live.cadence.epoch": "플롯은 에포크마다 한 번 업데이트됩니다.",
-  "live.cadence.batch": "{batches}개 배치마다 및 에포크 종료 시 플롯이 업데이트됩니다."
+  "live.cadence.batch": "{batches}개 배치마다 및 에포크 종료 시 플롯이 업데이트됩니다.",
+  "bugs.report": "버그 신고",
+  "bugs.help": "여기에 문제를 설명한 다음 GitHub에서 새 이슈를 확인하고 제출하세요. 스크린샷도 추가할 수 있습니다.",
+  "bugs.description": "버그 설명",
+  "bugs.placeholder": "무슨 일이 발생했나요? 예상한 결과는 무엇인가요? 어떻게 재현할 수 있나요?",
+  "bugs.tooLong": "설명이 너무 길어 전달할 수 없습니다. 내용을 줄인 다음 GitHub에서 나머지 세부 사항을 추가하세요.",
+  "bugs.continue": "GitHub에서 계속"
 }

--- a/frontend/src/i18n/nl.json
+++ b/frontend/src/i18n/nl.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "Batches tussen voorbeelden",
   "form.preview.warning": "Frequente batchvoorbeelden kunnen de training ernstig vertragen. Elk voorbeeld vereist extra inferentie en grafiekberekeningen.",
   "live.cadence.epoch": "Grafieken worden eenmaal per epoch bijgewerkt.",
-  "live.cadence.batch": "Grafieken worden elke {batches} batches en aan het einde van de epoch bijgewerkt."
+  "live.cadence.batch": "Grafieken worden elke {batches} batches en aan het einde van de epoch bijgewerkt.",
+  "bugs.report": "Bugs melden",
+  "bugs.help": "Beschrijf het probleem hier en ga verder op GitHub om je nieuwe issue te controleren en in te dienen. Daar kun je screenshots toevoegen.",
+  "bugs.description": "Beschrijving van de bug",
+  "bugs.placeholder": "Wat gebeurde er? Wat verwachtte je? Hoe kunnen we dit reproduceren?",
+  "bugs.tooLong": "Deze beschrijving is te lang om over te nemen. Kort de tekst in en voeg de rest toe op GitHub.",
+  "bugs.continue": "Verder op GitHub"
 }

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -784,5 +784,11 @@
   "form.preview.batches": "预览间隔 batch 数",
   "form.preview.warning": "频繁按 batch 预览可能严重影响训练速度。每次预览都会额外执行推理和绘图计算。",
   "live.cadence.epoch": "绘图每个 epoch 更新一次。",
-  "live.cadence.batch": "绘图每 {batches} 个 batch 及 epoch 结束时更新。"
+  "live.cadence.batch": "绘图每 {batches} 个 batch 及 epoch 结束时更新。",
+  "bugs.report": "报告问题",
+  "bugs.help": "在这里描述问题，然后前往 GitHub 检查并提交新 Issue。你可以在那里添加截图。",
+  "bugs.description": "问题描述",
+  "bugs.placeholder": "发生了什么？预期结果是什么？如何复现？",
+  "bugs.tooLong": "描述太长，无法完整传递。请缩短内容，再到 GitHub 补充其余细节。",
+  "bugs.continue": "前往 GitHub"
 }

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -24,6 +24,7 @@ import { useCapabilities, useRun, useRuns } from '@/api/hooks'
 import { WEB_MODE, type WebSessionInfo } from '@/api/client'
 import { LanguageMenu } from '@/components/LanguageMenu'
 import { ResetButton } from '@/components/ResetButton'
+import { ReportBugsButton } from '@/components/ReportBugsButton'
 import { StudioLogo } from '@/components/StudioLogo'
 import { ExperimentTerminal } from '@/components/ExperimentTerminal'
 import { isExperimentTask } from '@/components/ExperimentTasks'
@@ -73,7 +74,7 @@ export function AppShell() {
   }
   const count = running.data?.length ?? 0
   const wideNavigation = useMediaQuery('(min-width: 900px)')
-  const compactToolbar = useMediaQuery('(max-width: 899px)')
+  const compactToolbar = useMediaQuery('(max-width: 1099px)')
   const width = { xs: 64, md: tokens.layout.navWidth }
   const active = (to: string) => to === '/' ? pathname === '/' : pathname === to || pathname.startsWith(`${to}/`) || (to === '/experiments' && pathname.startsWith('/runs/'))
   const current = NAV.find(({ to }) => active(to))
@@ -110,12 +111,13 @@ export function AppShell() {
       </Drawer>
       <AppBar position="fixed" color="default" elevation={0} sx={{ width: { xs: 'calc(100% - 64px)', md: `calc(100% - ${tokens.layout.navWidth}px)` }, border: 0, borderBottom: `1px solid ${colors.border}`, bgcolor: 'background.paper' }}>
         <Toolbar sx={{ minHeight: '56px !important', gap: { xs: .5, sm: 1, lg: 1.5 }, px: { xs: '8px !important', sm: '16px !important', lg: '20px !important' } }}>
-          <Typography variant="body2" noWrap sx={{ fontWeight: 600, minWidth: 0 }}>{current ? t(current.key) : t('app.title')}</Typography>
+          <Typography variant="body2" noWrap sx={{ fontWeight: 600, minWidth: 0, display: { xs: 'none', sm: 'block' } }}>{current ? t(current.key) : t('app.title')}</Typography>
           <Box sx={{ height: 16, borderLeft: `1px solid ${colors.border}`, display: { xs: 'none', lg: 'block' } }} />
           <Typography variant="body2" color="text.secondary" noWrap sx={{ maxWidth: 380, minWidth: 0, display: { xs: 'none', lg: 'block' } }} title={caps.data?.workspace}>
             {caps.data?.workspace.split(/[\\/]/).filter(Boolean).at(-1) ?? '…'}
           </Typography>
           <Box sx={{ flex: 1 }} />
+          <ReportBugsButton compact={compactToolbar} />
           <ResetButton compact={compactToolbar} disabled={mutating} detail={resetDetail} onReset={() => reset(false)} />
           <ResetButton compact={compactToolbar} scope="studio" disabled={mutating} onReset={() => reset(true)} />
           <Chip size="small" sx={{ display: { xs: 'none', sm: 'flex' }, flexShrink: 0 }} color={count > 0 ? 'info' : 'default'} variant="outlined" label={count > 0 ? t('topbar.nowRunning', { count }) : t('topbar.idle')} data-testid="now-running" />

--- a/frontend/src/pages/SessionGate.tsx
+++ b/frontend/src/pages/SessionGate.tsx
@@ -1,5 +1,6 @@
 import Alert from '@mui/material/Alert'
 import Button from '@mui/material/Button'
+import Box from '@mui/material/Box'
 import Paper from '@mui/material/Paper'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
@@ -9,6 +10,7 @@ import { useEffect, useState, type FormEvent, type ReactNode } from 'react'
 import { WEB_MODE, bootstrapSession, clearWebSession, createWebSession, loadSession } from '@/api/client'
 import { t } from '@/i18n'
 import { ErrorState, LoadingState } from '@/components/StateBlock'
+import { ReportBugsButton } from '@/components/ReportBugsButton'
 
 /** Renders children only with a valid local session; otherwise explains how to get one. */
 export function SessionGate({ children }: { children: ReactNode }) {
@@ -34,11 +36,13 @@ export function SessionGate({ children }: { children: ReactNode }) {
   }, [qc, expiresAt])
 
   if (session.isPending) return <LoadingState />
-  if (session.isError) return <ErrorState error={session.error} onRetry={() => void session.refetch()} />
+  const reportBugs = <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}><ReportBugsButton /></Box>
+  if (session.isError) return <Stack sx={{ maxWidth: 560, mx: 'auto', p: 3 }} spacing={2}>{reportBugs}<ErrorState error={session.error} onRetry={() => void session.refetch()} /></Stack>
   if (session.data.authenticated) return <>{children}</>
 
   if (WEB_MODE) return <Paper sx={{ maxWidth: 560, mx: 'auto', my: '10vh', p: 3 }}>
     <Stack spacing={2}>
+      {reportBugs}
       <Typography variant="h1">{t('web.welcome')}</Typography>
       <Typography>{t('web.description')}</Typography>
       <Alert severity="info">{t('web.temporary')}</Alert>
@@ -70,6 +74,7 @@ export function SessionGate({ children }: { children: ReactNode }) {
   return (
     <Paper component="form" onSubmit={(e) => void submit(e)} sx={{ maxWidth: 560, m: '10vh auto', p: 3 }}>
       <Stack spacing={2}>
+        {reportBugs}
         <Typography variant="h1">{t('session.required.title')}</Typography>
         <Typography>{t('session.required.body')}</Typography>
         {invalid && <Alert severity="error">{t('session.token.invalid')}</Alert>}

--- a/opendpd/__init__.py
+++ b/opendpd/__init__.py
@@ -8,7 +8,7 @@ Lab of Efficient Machine Intelligence @ Delft University of Technology
 Website: https://www.tudemi.com
 """
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 __author__ = "Yizhuo Wu, Ang Li, Chang Gao"
 __license__ = "Apache-2.0"
 __email__ = "chang.gao@tudelft.nl"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendpd"
-version = "2.2.1"
+version = "2.2.2"
 description = "An end-to-end learning framework for modeling power amplifiers and digital pre-distortion"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Task

Add a ready-to-type bug reporting entry point to Studio and release 2.2.2.

## User problem

Users need to report GUI problems without losing their current experiment or finding the repository manually. GitHub's new-issue page currently focuses the title and assigns generated IDs to its description editor, so cross-site links cannot reliably focus that editor.

## Scope / Non-goals

Add a top-toolbar Report bugs button and an automatically focused description dialog. Continue on GitHub opens the OpenDPD new-issue form in another tab with the user's text and public Studio version prefilled; the user reviews and submits it there. The same control works on session-start and connection-error screens. Preserve a dismissed draft, restore keyboard focus, bound the encoded URL, translate all nine languages and keep mobile toolbar controls within the viewport. Bump package/frontend/contract versions to 2.2.2 and update release documentation.

No automatic issue submission or attachment of workspace paths, tokens, logs, dataset contents or run details. Compute, uploads, isolation and cleanup behavior remain unchanged.

## Acceptance evidence

- Frontend strict types, lint and 38 existing shell/session/catalogue tests passed.
- OpenAPI synchronization and frontend-mock synchronization passed; web/native builds and strict documentation build passed.
- Browser checks confirmed initial textarea focus, typing without another click, Escape/focus restoration and draft preservation, and the mobile description layout.
- Authenticated GitHub UI verified correct prefill of multiline text, Chinese, ampersands, hash characters and version 2.2.2. No test issue was submitted.
- Repository CI must pass before merge. Live deployment and remote browser verification follow merge; package publication and distribution hashes are verified afterward.

## Unfinished / follow-ups

Deployment/release validation is recorded with the 2.2.2 release assets once complete. GitHub controls its own keyboard focus and may require the user to sign in.

## Risk / approvals

- [ ] Touches a protected scientific path.
- [x] Release and deployment requested and authorized by the repository owner in this task. No runtime permissions or security boundaries change.

## Rollback

Revert this commit and republish the prior frontend. Deployment preserves the 2.2.1 source and GPU image for rollback.
